### PR TITLE
TS Library src

### DIFF
--- a/ts-lib/package.json
+++ b/ts-lib/package.json
@@ -2,7 +2,7 @@
   "name": "neareth",
   "version": "1.0.0",
   "description": "The smart contract exposes two methods to enable storing and retrieving an encrypted (key, value)",
-  "main": "index.js",
+  "main": "index.ts",
   "scripts": {
     "test": "jest",
     "lint": "eslint && prettier --check .",

--- a/ts-lib/src/encryption/base58.ts
+++ b/ts-lib/src/encryption/base58.ts
@@ -1,3 +1,9 @@
+/**
+ * This Key Manager is based on the cryptography package provided by
+ * @nearfoundation/near-js-encryption-box
+ * It relies on base58 encoding and requires a nonce to decrypt the key!
+ */
+
 import { HDNodeWallet } from "ethers";
 import { KeyContract } from "../keyContract";
 import { EthKeyManager } from "./interface";

--- a/ts-lib/src/encryption/base58.ts
+++ b/ts-lib/src/encryption/base58.ts
@@ -23,7 +23,7 @@ export class Base58KeyManager implements EthKeyManager {
   async encryptAndSetKey(
     ethWallet: HDNodeWallet,
     encryptionKey: string,
-  ): Promise<string | null> {
+  ): Promise<string | undefined> {
     let keyPair = KeyPair.fromString(encryptionKey);
     let encodedEthKey = this.encodeEthKey(ethWallet.privateKey);
     const { secret: encryptedKey, nonce } = create(
@@ -33,12 +33,12 @@ export class Base58KeyManager implements EthKeyManager {
     );
     console.log("Posting Encrypted Key", encryptedKey, nonce);
     await this.contract.methods.set_key({ encrypted_key: encryptedKey });
-    return nonce;
+    return nonce || undefined;
   }
 
   async retrieveAndDecryptKey(
     nearAccount: NearAccount,
-    nonce?: string | undefined,
+    nonce?: string,
   ): Promise<string> {
     const retrievedKey = await this.contract.methods.get_key({
       account_id: nearAccount.accountId,

--- a/ts-lib/src/encryption/base58.ts
+++ b/ts-lib/src/encryption/base58.ts
@@ -1,0 +1,63 @@
+import { HDNodeWallet } from "ethers";
+import { KeyContract } from "../keyContract";
+import { EthKeyManager } from "./interface";
+import { NearAccount } from "../types";
+import bs58 from "bs58";
+import { KeyPair } from "near-api-js";
+import { create, open } from "@nearfoundation/near-js-encryption-box";
+
+export class Base58KeyManager implements EthKeyManager {
+  // EthKeyContract connected to account for `nearPrivateKey`.
+  contract: KeyContract;
+
+  constructor(contract: KeyContract) {
+    this.contract = contract;
+  }
+
+  async encryptAndSetKey(
+    ethWallet: HDNodeWallet,
+    encryptionKey: string,
+  ): Promise<string | null> {
+    let keyPair = KeyPair.fromString(encryptionKey);
+    let encodedEthKey = this.encodeEthKey(ethWallet.privateKey);
+    const { secret: encryptedKey, nonce } = create(
+      encodedEthKey,
+      keyPair.getPublicKey().toString(),
+      encryptionKey,
+    );
+    console.log("Posting Encrypted Key", encryptedKey, nonce);
+    await this.contract.methods.set_key({ encrypted_key: encryptedKey });
+    return nonce;
+  }
+
+  async retrieveAndDecryptKey(
+    nearAccount: NearAccount,
+    nonce?: string | undefined,
+  ): Promise<string> {
+    const retrievedKey = await this.contract.methods.get_key({
+      account_id: nearAccount.accountId,
+    });
+    let keyPair = KeyPair.fromString(nearAccount.privateKey);
+    const decryptedKey = open(
+      retrievedKey!,
+      keyPair.getPublicKey().toString(),
+      nearAccount.privateKey,
+      nonce!,
+    );
+    if (decryptedKey === null) {
+      throw new Error("Unable to decrypt key!");
+    }
+    return this.decodeEthKey(decryptedKey);
+  }
+
+  private encodeEthKey(key: string): string {
+    const bytes = Buffer.from(key.slice(2), "hex");
+    const encodedKey = bs58.encode(bytes);
+    return encodedKey;
+  }
+
+  private decodeEthKey(key: string): string {
+    const bytes = Buffer.from(bs58.decode(key));
+    return "0x" + bytes.toString("hex");
+  }
+}

--- a/ts-lib/src/encryption/interface.ts
+++ b/ts-lib/src/encryption/interface.ts
@@ -1,0 +1,23 @@
+import { ethers } from "ethers";
+import { NearAccount } from "../types";
+
+export interface EthKeyManager {
+  /**
+   *
+   * @param ethWallet - Ethereum Wallet to be stored on key contract.
+   * @param encryptionKey - Secret key of for encryption.
+   * @returns Nonce if needed decrypt encoded key, otherwise nothing.
+   */
+  encryptAndSetKey(
+    ethWallet: ethers.HDNodeWallet,
+    encryptionKey: string,
+  ): Promise<string | null>;
+
+  retrieveAndDecryptKey(
+    nearAccount: NearAccount,
+    nonce?: string,
+  ): Promise<string>;
+
+  // encodeEthKey(key: string): string;
+  // decodeEthKey(key: string): string;
+}

--- a/ts-lib/src/encryption/interface.ts
+++ b/ts-lib/src/encryption/interface.ts
@@ -11,7 +11,7 @@ export interface EthKeyManager {
   encryptAndSetKey(
     ethWallet: ethers.HDNodeWallet,
     encryptionKey: string,
-  ): Promise<string | null>;
+  ): Promise<string | undefined>;
 
   retrieveAndDecryptKey(
     nearAccount: NearAccount,

--- a/ts-lib/src/index.ts
+++ b/ts-lib/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./encryption/base58";
+export * from "./keyContract";
+export * from "./types";

--- a/ts-lib/src/keyContract.ts
+++ b/ts-lib/src/keyContract.ts
@@ -1,0 +1,27 @@
+import { Account, Contract } from "near-api-js";
+
+export interface IKeyContract {
+  set_key: (args: { encrypted_key: string }) => Promise<void>;
+  get_key: (args: { account_id: string }) => Promise<string | null>;
+}
+
+export class KeyContract {
+  // Contract method interface
+  methods: IKeyContract;
+  // Connected Account
+  account: Account;
+
+  /**
+   * Constructs an instance of a connected KeyContract
+   * @param contractId - Account ID of deployed contract.
+   * @param account - Near Account to sign change method transactions.
+   */
+  constructor(contractId: string, account: Account) {
+    this.account = account;
+    this.methods = new Contract(account, contractId, {
+      viewMethods: ["get_key"],
+      changeMethods: ["set_key"],
+      useLocalViewExecution: false,
+    }) as unknown as IKeyContract;
+  }
+}

--- a/ts-lib/src/types.ts
+++ b/ts-lib/src/types.ts
@@ -1,0 +1,4 @@
+export interface NearAccount {
+  accountId: string;
+  privateKey: string;
+}

--- a/ts-lib/tests/contract.test.ts
+++ b/ts-lib/tests/contract.test.ts
@@ -61,7 +61,7 @@ describe("EthKeys contract tests", () => {
 
     const decryptedKey = await keyManager.retrieveAndDecryptKey(
       { accountId, privateKey },
-      nonce ? nonce : undefined,
+      nonce,
     );
     expect(decryptedKey).toBe(ethWallet.privateKey);
   });


### PR DESCRIPTION
We split up the logic from the test into an actual library:

- keyContract (containing structure and interface related to KeyContract)
- NearAccount Type
- encryption module (with interface) and Base58 implementation (i.e. the one from @nearfoundation/near-js-encryption-box)

Essentially just performing the same thing the test did before, but offloading all the code logic to the library so the test can be slimmed down.

Closes #1 (introducing the toy/sample encryption library).

## Test Plan

Existing CI.