### PR TITLE
Consistent Encryption API

### DIFF
--- a/ts-lib/src/encryption/cryptojs.ts
+++ b/ts-lib/src/encryption/cryptojs.ts
@@ -4,10 +4,9 @@
  * It relies on base58 encoding and requires a nonce to decrypt the key!
  */
 
-import { HDNodeWallet } from "ethers";
 import { KeyContract } from "../keyContract";
 import { EthKeyManager } from "./interface";
-import { NearAccount } from "../types";
+import { EthPrivateKey, NearAccount } from "../types";
 import CryptoJS from "crypto-js";
 
 export class CryptoJSKeyManager implements EthKeyManager {
@@ -19,11 +18,11 @@ export class CryptoJSKeyManager implements EthKeyManager {
   }
 
   async encryptAndSetKey(
-    ethWallet: HDNodeWallet,
+    ethPrivateKey: EthPrivateKey,
     encryptionKey: string,
   ): Promise<string | undefined> {
     let encryptedKey = CryptoJS.AES.encrypt(
-      ethWallet.privateKey,
+      ethPrivateKey.toString(),
       encryptionKey,
     );
     console.log("Posting Encrypted Key", encryptedKey.toString());
@@ -36,11 +35,14 @@ export class CryptoJSKeyManager implements EthKeyManager {
   async retrieveAndDecryptKey(
     nearAccount: NearAccount,
     // nonce?: string | undefined,
-  ): Promise<string> {
+  ): Promise<EthPrivateKey> {
     const retrievedKey = await this.contract.methods.get_key({
       account_id: nearAccount.accountId,
     });
-    let bytes = CryptoJS.AES.decrypt(retrievedKey!, nearAccount.privateKey);
-    return bytes.toString(CryptoJS.enc.Utf8);
+    let bytes = CryptoJS.AES.decrypt(
+      retrievedKey!,
+      nearAccount.privateKey.toString(),
+    );
+    return new EthPrivateKey(bytes.toString(CryptoJS.enc.Utf8));
   }
 }

--- a/ts-lib/src/encryption/interface.ts
+++ b/ts-lib/src/encryption/interface.ts
@@ -1,23 +1,19 @@
-import { ethers } from "ethers";
-import { NearAccount } from "../types";
+import { EthPrivateKey, NearAccount } from "../types";
 
 export interface EthKeyManager {
   /**
    *
-   * @param ethWallet - Ethereum Wallet to be stored on key contract.
+   * @param ethPrivateKey - Ethereum Private Key to be stored on key contract.
    * @param encryptionKey - Secret key of for encryption.
    * @returns Nonce if needed decrypt encoded key, otherwise nothing.
    */
   encryptAndSetKey(
-    ethWallet: ethers.HDNodeWallet,
+    ethPrivateKey: EthPrivateKey,
     encryptionKey: string,
   ): Promise<string | undefined>;
 
   retrieveAndDecryptKey(
     nearAccount: NearAccount,
     nonce?: string,
-  ): Promise<string>;
-
-  // encodeEthKey(key: string): string;
-  // decodeEthKey(key: string): string;
+  ): Promise<EthPrivateKey>;
 }

--- a/ts-lib/src/types.ts
+++ b/ts-lib/src/types.ts
@@ -33,7 +33,7 @@ export class NearPrivateKey {
 
   constructor(key: string) {
     if (!this.isNearPrivateKey(key)) {
-      throw new Error("Invalid Ethereum private key");
+      throw new Error("Invalid Near private key");
     }
     this.key = key;
   }

--- a/ts-lib/src/types.ts
+++ b/ts-lib/src/types.ts
@@ -1,4 +1,57 @@
+// TODO - can validate whether key provided can actually control accountId
+//  however, it requires calls to near.
 export interface NearAccount {
   accountId: string;
-  privateKey: string;
+  privateKey: NearPrivateKey;
+}
+
+export class EthPrivateKey {
+  private key: string;
+
+  constructor(key: string) {
+    if (!this.isValidEthPrivateKey(key)) {
+      throw new Error("Invalid Ethereum private key");
+    }
+    this.key = key;
+  }
+
+  private isValidEthPrivateKey(key: string): boolean {
+    const hexRegex = /^[a-fA-F0-9]{64}$/;
+    return (
+      typeof key === "string" &&
+      hexRegex.test(key.startsWith("0x") ? key.slice(2) : key)
+    );
+  }
+
+  toString(): string {
+    return this.key;
+  }
+}
+
+export class NearPrivateKey {
+  private key: string;
+
+  constructor(key: string) {
+    if (!this.isNearPrivateKey(key)) {
+      throw new Error("Invalid Ethereum private key");
+    }
+    this.key = key;
+  }
+
+  private isNearPrivateKey(key: any): boolean {
+    const prefix = "ed25519:";
+    // Base58 regex excluding 0, O, I, and l
+    const base58Regex = /^[A-HJ-NP-Za-km-z1-9]+$/;
+
+    if (typeof key !== "string" || !key.startsWith(prefix)) {
+      return false;
+    }
+
+    const keyPart = key.substring(prefix.length);
+    return base58Regex.test(keyPart);
+  }
+
+  toString(): string {
+    return this.key;
+  }
 }

--- a/ts-lib/tests/types.test.ts
+++ b/ts-lib/tests/types.test.ts
@@ -1,0 +1,17 @@
+import { EthPrivateKey, NearPrivateKey } from "../src/types";
+
+
+describe("Type Validation", () => {
+
+  it("Validates EthPrivateKey Construction", async () => {
+    const validKey = "0x38b499b2263de8d23944746a6922757e8da6184828d98fbfd6c88ebee1fad111";
+    expect(() => new EthPrivateKey(validKey)).not.toThrow();
+    expect(() => new EthPrivateKey('invalid key')).toThrow("Invalid Ethereum private key");
+  });
+
+  it("Validates NearPrivateKey Construction", async () => {
+    const validKey = "ed25519:TxtD94WwG6VRnJbwdhwJX4KASbSXXwovSJ3a6PK8cM63fuWcuXQ4zTTRzSmF2r8Af2bvKWKvNDyfcGRbVXbqCL1";
+    expect(() => new NearPrivateKey(validKey)).not.toThrow();
+    expect(() => new NearPrivateKey('invalid key')).toThrow("Invalid Near private key");
+  });
+});


### PR DESCRIPTION
_This is equivalent to #10 which got closed because the base branch was merged and deleted._ 

Instead of passing Wallet object to be encrypted we pass a privateKey (all that is actually used) which is the same type that is returned by decryption.

Note that we also introduced some validation on the types passed through this Key Manager.

## Test Plan

Added test for key validation + modified existing tests to continue with new interface types.
